### PR TITLE
Fixing compatibility for usage with ESP32 core

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -632,6 +632,16 @@ int MqttClient::connect(const char *host, uint16_t port)
   return connect((uint32_t)0, host, port);
 }
 
+int MqttClient::connect(IPAddress ip, uint16_t port, int /* timeout */)
+{
+  return connect(ip, port);
+}
+
+int MqttClient::connect(const char *host, uint16_t port, int /* timeout */)
+{
+  return connect(host, port);
+}
+
 size_t MqttClient::write(uint8_t b)
 {
   return write(&b, sizeof(b));

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -67,6 +67,8 @@ public:
   // from Client
   virtual int connect(IPAddress ip, uint16_t port = 1883);
   virtual int connect(const char *host, uint16_t port = 1883);
+  virtual int connect(IPAddress ip, uint16_t port, int timeout);
+  virtual int connect(const char *host, uint16_t port, int timeout);
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   virtual int available();


### PR DESCRIPTION
ESP32 core class `Client` defines two additional pure virtual `connect` functions which are leading to a compilation error (class `MqttClient` becomes an abstract class and can not be instantiated, since it does not provide implementations for those pure virtual functions). This commit provides this implementation allowing the class `MqttClient` to be used with the ESP32 core