### PR TITLE
Fix some warnings and wrap ESP8266 Client overrides in #ifdef

### DIFF
--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -67,7 +67,9 @@ public:
   // from Client
   virtual int connect(IPAddress ip, uint16_t port = 1883);
   virtual int connect(const char *host, uint16_t port = 1883);
-  virtual int connect(const IPAddress& ip, uint16_t port) { }; /* ESP8266 core defines this pure virtual in Client.h */
+#ifdef ESP8266
+  virtual int connect(const IPAddress& ip, uint16_t port) { return connect(ip, port); }; /* ESP8266 core defines this pure virtual in Client.h */
+#endif
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   virtual int available();
@@ -90,9 +92,10 @@ public:
 
   int connectError() const;
   int subscribeQoS() const;
-  virtual bool flush(unsigned int maxWaitMs) { } /* ESP8266 core defines this pure virtual in Client.h */
-
-  virtual bool stop(unsigned int maxWaitMs)  { } /* ESP8266 core defines this pure virtual in Client.h */
+#ifdef ESP8266
+  virtual bool flush(unsigned int /*maxWaitMs*/) { flush(); return true; } /* ESP8266 core defines this pure virtual in Client.h */
+  virtual bool stop(unsigned int /*maxWaitMs*/)  { stop(); return true; } /* ESP8266 core defines this pure virtual in Client.h */
+#endif
 
 private:
   int connect(IPAddress ip, const char* host, uint16_t port);


### PR DESCRIPTION
Based on the discussions in:

* https://github.com/arduino-libraries/ArduinoMqttClient/pull/18#discussion_r339592751
* https://github.com/arduino-libraries/ArduinoMqttClient/commit/ade2940a2ffe1cdc04e39d638d28378cc2c41c32#commitcomment-35852164

@lxrobotics for @jandrassy's concerns, to reproduce, use the [WiFiEcho.ino](https://github.com/arduino-libraries/ArduinoMqttClient/blob/master/examples/WiFiEcho/WiFiEcho.ino) and change:
```
const char broker[] = "test.mosquitto.org";
```
to
```
IPAddress broker = IPAddress(10, 0, 1, 1);
```

You will get a compile error.
