### PR TITLE
Removing default value assignment within connect function

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -12,8 +12,8 @@ jobs:
          "arduino:samd:mkr1000",
          "arduino:samd:mkrwifi1010",
          "arduino:samd:nano_33_iot",
-         "arduino:megaavr:uno2018",
-         '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"'
+         "arduino:megaavr:uno2018"
+#         '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"'
        ]
 
    steps:

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -623,7 +623,7 @@ void MqttClient::poll()
   }
 }
 
-#ifndef ESP8266
+#ifndef ARDUINO_ARCH_ESP8266
 int MqttClient::connect(IPAddress ip, uint16_t port)
 #else
 int MqttClient::connect(const IPAddress& ip, uint16_t port)

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -623,7 +623,11 @@ void MqttClient::poll()
   }
 }
 
+#ifndef ESP8266
 int MqttClient::connect(IPAddress ip, uint16_t port)
+#else
+int MqttClient::connect(const IPAddress& ip, uint16_t port)
+#endif
 {
   return connect(ip, NULL, port);
 }

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -66,7 +66,7 @@ public:
 
   // from Client
   virtual int connect(const char *host, uint16_t port);
-#ifndef ESP8266
+#ifndef ARDUINO_ARCH_ESP8266
   virtual int connect(IPAddress ip, uint16_t port);
 #else
   virtual int connect(const IPAddress& ip, uint16_t port); /* ESP8266 core 2.5.0 defines this pure virtual in Client.h */

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -65,10 +65,11 @@ public:
   void poll();
 
   // from Client
-  virtual int connect(IPAddress ip, uint16_t port);
   virtual int connect(const char *host, uint16_t port);
-#ifdef ESP8266
-  virtual int connect(const IPAddress& ip, uint16_t port) { return 0; }; /* ESP8266 core defines this pure virtual in Client.h */
+#ifndef ESP8266
+  virtual int connect(IPAddress ip, uint16_t port);
+#else
+  virtual int connect(const IPAddress& ip, uint16_t port); /* ESP8266 core 2.5.0 defines this pure virtual in Client.h */
 #endif
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -65,8 +65,8 @@ public:
   void poll();
 
   // from Client
-  virtual int connect(IPAddress ip, uint16_t port = 1883);
-  virtual int connect(const char *host, uint16_t port = 1883);
+  virtual int connect(IPAddress ip, uint16_t port);
+  virtual int connect(const char *host, uint16_t port);
 #ifdef ESP8266
   virtual int connect(const IPAddress& ip, uint16_t port) { return 0; }; /* ESP8266 core defines this pure virtual in Client.h */
 #endif


### PR DESCRIPTION
This change is catching two things at once ...
1) we don't have the ugly function to stay complian to ESP8266 core `2.5.0` and 
2) we don't have overload function resolving problems when actually using `connect` with an `IPAddress` argument (as is done  [here](https://github.com/arduino-libraries/ArduinoIoTCloud/pull/104)).
Drawback: This will break all sketches which have relied on the default parameter being set. (Note for the future: Default parameters are really dangerous).