### PR TITLE
Add support for using std::function callbacks instead of C-pointers

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -97,10 +97,17 @@ MqttClient::~MqttClient()
   }
 }
 
+#ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
+void MqttClient::onMessage(MqttMessageCallback callback)
+{
+  _onMessage = callback;
+}
+#else
 void MqttClient::onMessage(void(*callback)(int))
 {
   _onMessage = callback;
 }
+#endif
 
 int MqttClient::parseMessage()
 {
@@ -550,7 +557,11 @@ void MqttClient::poll()
             _rxState = MQTT_CLIENT_RX_STATE_READ_PUBLISH_PAYLOAD;
 
             if (_onMessage) {
+#ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
+              _onMessage(this,_rxLength);
+#else
               _onMessage(_rxLength);
+#endif
 
               if (_rxLength == 0) {
                 _rxState = MQTT_CLIENT_RX_STATE_READ_TYPE;
@@ -573,7 +584,11 @@ void MqttClient::poll()
           _rxState = MQTT_CLIENT_RX_STATE_READ_PUBLISH_PAYLOAD;
 
           if (_onMessage) {
+#ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
+            _onMessage(this,_rxLength);
+#else
             _onMessage(_rxLength);
+#endif
           }
 
           if (_rxLength == 0) {

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -98,7 +98,7 @@ MqttClient::~MqttClient()
 }
 
 #ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
-void MqttClient::onMessage(MqttMessageCallback callback)
+void MqttClient::onMessage(MessageCallback callback)
 #else
 void MqttClient::onMessage(void(*callback)(int))
 #endif

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -99,15 +99,12 @@ MqttClient::~MqttClient()
 
 #ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
 void MqttClient::onMessage(MqttMessageCallback callback)
-{
-  _onMessage = callback;
-}
 #else
 void MqttClient::onMessage(void(*callback)(int))
+#endif
 {
   _onMessage = callback;
 }
-#endif
 
 int MqttClient::parseMessage()
 {

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -141,7 +141,7 @@ private:
   Client* _client;
 
 #ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
-  MqttClient::MessageCallback _onMessage;
+  MessageCallback _onMessage;
 #else
   void (*_onMessage)(int);
 #endif

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -32,12 +32,24 @@
 #define MQTT_BAD_USER_NAME_OR_PASSWORD      4
 #define MQTT_NOT_AUTHORIZED                 5
 
+// Make this definition in your application code to use std::functions for onMessage callbacks instead of C-pointers:
+// #define MQTT_CLIENT_STD_FUNCTION_CALLBACK
+
+#ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
+#include <functional>
+#endif
+
 class MqttClient : public Client {
 public:
   MqttClient(Client& client);
   virtual ~MqttClient();
 
+#ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
+  typedef std::function<void(MqttClient *client, int messageSize)> MessageCallback;
+  void onMessage(MessageCallback callback);
+#else
   void onMessage(void(*)(int));
+#endif
 
   int parseMessage();
   String messageTopic() const;
@@ -128,7 +140,11 @@ private:
 private:
   Client* _client;
 
+#ifdef MQTT_CLIENT_STD_FUNCTION_CALLBACK
+  MqttClient::MessageCallback _onMessage;
+#else
   void (*_onMessage)(int);
+#endif
 
   String _id;
   String _username;


### PR DESCRIPTION
When writing more structured Arduino code, it may be desirable to have an instance of `MqttClient` be encapsulated inside another object e.g. `MyMqttIntegration`.  In this case, the exclusive use of C-pointers for message callbacks becomes a problem since a member function of `MyMqttIntegration` cannot be presented as a C-pointer.  It is possible to cast a captureless lambda as a C-pointer, but this has it's own limitations.

This PR provides a solution: the current C-pointer API remains the default, but by defining `MQTT_CLIENT_STD_FUNCTION_CALLBACK` the library swaps to using `std::function`s.
Such a callback can then be defined by a lambda or by using `std::bind` on a member function.

Example setting of message callback when `MQTT_CLIENT_STD_FUNCTION_CALLBACK` is defined:

    MqttClient::MessageCallback callback = [this](MqttClient *client, int messageSize) {
        Serial.print("Received message with topic: " + client->messageTopic());
    };
    mqttClient->onMessage(callback);

Including a pointer to the source `MqttClient` affords a little extra flexibility in case multiple `MqttClient`s are used which share the same callback function.