### PR TITLE
Adding an additional ArduinoMqttClient constructor as well as a method setClient to allow late initialisation.

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -61,8 +61,8 @@ enum {
   MQTT_CLIENT_RX_STATE_DISCARD_PUBLISH_PAYLOAD
 };
 
-MqttClient::MqttClient(Client& client) :
-  _client(&client),
+MqttClient::MqttClient(Client* client) :
+  _client(client),
   _onMessage(NULL),
   _cleanSession(true),
   _keepAliveInterval(60 * 1000L),
@@ -80,6 +80,11 @@ MqttClient::MqttClient(Client& client) :
   _willFlags(0x00)
 {
   setTimeout(0);
+}
+
+MqttClient::MqttClient(Client& client) : MqttClient(&client)
+{
+
 }
 
 MqttClient::~MqttClient()

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -34,8 +34,13 @@
 
 class MqttClient : public Client {
 public:
+  MqttClient(Client* client);
   MqttClient(Client& client);
   virtual ~MqttClient();
+
+
+  inline void setClient(Client& client) { _client = &client; }
+
 
   void onMessage(void(*)(int));
 


### PR DESCRIPTION
This allows for the ArduinoIoTCloud firmware to intantiate ArduinoMqttClient on the stack instead of the heap. So instead of
```C++
ArduinoMqttClient mqtt_client(another_client_interface);
```
you can do
```C++
ArduinoMqttClient mqtt_client(nullptr);
/* ... some time later the other client interface actually is available */
mqtt_client.setClient(late_available_client_interface);
```