### PR TITLE
Remove obsolete workaround for ESP8266 in compilation test CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -21,14 +21,7 @@ jobs:
        with:
          fetch-depth: 1
      - name: compile-examples for official Arduino boards
-       if: startsWith(matrix.fqbn, '"esp8266:esp8266') != true
        uses: arduino/actions/libraries/compile-examples@master
        with:
          fqbn: ${{ matrix.fqbn }}
          libraries: ${{ env.LIBRARIES }}
-     - name: compile-examples for ESP8266 boards
-       if: startsWith(matrix.fqbn, '"esp8266:esp8266')
-       uses: arduino/actions/libraries/compile-examples@master
-       with:
-         fqbn: ${{ matrix.fqbn }}
-         entrypoint: /github/workspace/.github/workflows/install-python-wrapper.sh

--- a/.github/workflows/install-python-wrapper.sh
+++ b/.github/workflows/install-python-wrapper.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -x
-# This script is used as an alternate entrypoint to allow installing Python 3 (a dependency of
-# the ESP8266 core for Arduino) in the Docker container used by the compile-examples action
-
-# Install Python 3
-apt-get update && apt-get install -y python3
-
-# Run the standard entrypoint script
-/entrypoint.sh "$@"


### PR DESCRIPTION
The ESP8266 platform has a tool dependency on python3, but assumes that tool is already installed in a particular location on Linux. At the time this workaround was added, the Docker container used by the arduino/actions/libraries/compile-examples action did not provide this tool, so a workaround was needed to install it in the container.

Since that time, the action has developed a dependency on Python, making this workaround unnecessary. The switch from the action being a Bash script to a Python script caused the now-unnecessary workaround to break the workflow.