### PR TITLE
Don't ack within 'read' if we are having a callback registered and reading from within the callback

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -713,7 +713,9 @@ int MqttClient::read(uint8_t *buf, size_t size)
       _rxLength -= result;
 
       if (_rxLength == 0) {
-        ackRxMessage();
+        if (!_onMessage) {
+          ackRxMessage();
+        }
 
         _rxState = MQTT_CLIENT_RX_STATE_READ_TYPE;
       }


### PR DESCRIPTION
Otherwise ACK is sent twice - once during `read` and once after the completion of the callback `_onMessage` handler.