### PR TITLE
Fix buffer overflow bug introduced in PR #44

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -802,6 +802,7 @@ void MqttClient::setConnectionTimeout(unsigned long timeout)
 
 void MqttClient::setTxPayloadSize(unsigned short size)
 {
+  // NOOJ WAS HERE
   _tx_payload_buffer_size = size;
 }
 

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -70,7 +70,6 @@ MqttClient::MqttClient(Client* client) :
   _keepAliveInterval(60 * 1000L),
   _connectionTimeout(30 * 1000L),
   _tx_payload_buffer_size(TX_PAYLOAD_BUFFER_SIZE),
-  _last_mallocd_size(0),         // DEBUG NOOJ
   _connectError(MQTT_SUCCESS),
   _connected(false),
   _subscribeQos(0x00),
@@ -667,36 +666,6 @@ size_t MqttClient::write(const uint8_t *buf, size_t size)
 
   if (_txPayloadBuffer == NULL) {
     _txPayloadBuffer = (uint8_t*)malloc(_tx_payload_buffer_size);
-    _last_mallocd_size = _tx_payload_buffer_size;  //DEBUG NOOJ
-  }
-
-  if (_txPayloadBufferIndex + size > _last_mallocd_size) {
-    log_e(
-      "MqttClient::write() ERROR: BUFFER OVERFLOW: _last_mallocd_size = %d, total bytes being written = %d", 
-      _last_mallocd_size, _txPayloadBufferIndex + size
-    );
-    
-    /* 
-     * Working example of buffer overflow bug:
-     *
-      // make my_settings > 512 chars
-      mqttClient.beginMessage(SETTINGS_TOPIC);
-      mqttClient.print(my_settings);            // prints first 256 chars of my_settings
-      mqttClient.endMessage();
-        
-      mqttClient.setTxPayloadSize(512);
-      mqttClient.beginMessage(SETTINGS_TOPIC);
-      mqttClient.print(my_settings);           // heap corruption
-      mqttClient.endMessage();
-        
-      // output 
-      [V][ssl_client.cpp:295] send_ssl_data(): Writing HTTP request with 17 bytes...
-      [V][ssl_client.cpp:295] send_ssl_data(): Writing HTTP request with 256 bytes...
-      [I][MqttClient.cpp:815] setTxPayloadSize(): MqttClient::setTxPayloadSize(): NOOJ says: _txPayloadBuffer should be freed and NULLed here.
-      [E][MqttClient.cpp:677] write(): MqttClient::write() ERROR: BUFFER OVERFLOW: _last_mallocd_size = 256, total bytes being written = 512
-      CORRUPT HEAP: multi_heap.c:432 detected at 0x3ffd6ab4
-      abort() was called at PC 0x4008d447 on core 1
-    */
   }
 
   memcpy(&_txPayloadBuffer[_txPayloadBufferIndex], buf, size);
@@ -833,16 +802,10 @@ void MqttClient::setConnectionTimeout(unsigned long timeout)
 
 void MqttClient::setTxPayloadSize(unsigned short size)
 {
-  // NOOJ WAS HERE
-  log_i("MqttClient::setTxPayloadSize(): NOOJ says: _txPayloadBuffer should be freed and NULLed here.");
-    
-  // TODO: Be clever and try to preserve existing _txPayloadBuffer contents?
-  // TODO: Check if this messes up the state of pending messages
   if (_txPayloadBuffer) {
     free(_txPayloadBuffer);
     _txPayloadBuffer = NULL;
     _txPayloadBufferIndex = 0;
-    _last_mallocd_size = 0;
   }
     
   _tx_payload_buffer_size = size;

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -842,6 +842,7 @@ void MqttClient::setTxPayloadSize(unsigned short size)
     free(_txPayloadBuffer);
     _txPayloadBuffer = NULL;
     _txPayloadBufferIndex = 0;
+    _last_mallocd_size = 0;
   }
     
   _tx_payload_buffer_size = size;

--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -835,6 +835,15 @@ void MqttClient::setTxPayloadSize(unsigned short size)
 {
   // NOOJ WAS HERE
   log_i("MqttClient::setTxPayloadSize(): NOOJ says: _txPayloadBuffer should be freed and NULLed here.");
+    
+  // TODO: Be clever and try to preserve existing _txPayloadBuffer contents?
+  // TODO: Check if this messes up the state of pending messages
+  if (_txPayloadBuffer) {
+    free(_txPayloadBuffer);
+    _txPayloadBuffer = NULL;
+    _txPayloadBufferIndex = 0;
+  }
+    
   _tx_payload_buffer_size = size;
 }
 

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -144,6 +144,7 @@ private:
   unsigned long _keepAliveInterval;
   unsigned long _connectionTimeout;
   unsigned short _tx_payload_buffer_size;
+  unsigned short _last_mallocd_size;
 
   int _connectError;
   bool _connected;

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -144,7 +144,6 @@ private:
   unsigned long _keepAliveInterval;
   unsigned long _connectionTimeout;
   unsigned short _tx_payload_buffer_size;
-  unsigned short _last_mallocd_size;
 
   int _connectError;
   bool _connected;


### PR DESCRIPTION
PR #44 introduced a buffer overflow bug that will corrupt the heap if the transmit payload size is increased after any send.  For an example of the bug, see below.

The patch included here will cause the existing tx payload buffer to be freed upon any call to MqttClient::setTxPayloadSize().  A subsequent call to MqttClient::write() will allocate space using the new tx payload size.  Data previously added to an outgoing message but not sent (via MqttClient::endMessage()) will be lost.


Minimal example:
// make test_string be a string of length > 256 characters
mqttClient.beginMessage("topic");
mqttClient.print(test_string);  // prints first 256 chars of my_settings
mqttClient.endMessage();
        
mqttClient.setTxPayloadSize(512);
mqttClient.beginMessage("topic");
mqttClient.print(test_string);  // heap corruption in version 46d65e3!
mqttClient.endMessage();
        
// output with CORE_DEBUG_LEVEL=5
[V][ssl_client.cpp:295] send_ssl_data(): Writing HTTP request with 17 bytes...
[V][ssl_client.cpp:295] send_ssl_data(): Writing HTTP request with 256 bytes...
CORRUPT HEAP: multi_heap.c:432 detected at 0x3ffd6ab4
abort() was called at PC 0x4008d447 on core 1