### PR TITLE
Fix buffer overflow introduced in #44.

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -802,6 +802,12 @@ void MqttClient::setConnectionTimeout(unsigned long timeout)
 
 void MqttClient::setTxPayloadSize(unsigned short size)
 {
+  if (_txPayloadBuffer) {
+    free(_txPayloadBuffer);
+    _txPayloadBuffer = NULL;
+    _txPayloadBufferIndex = 0;
+  }
+    
   _tx_payload_buffer_size = size;
 }
 


### PR DESCRIPTION
PR #44 introduced a buffer overflow bug that will corrupt the heap if the transmit payload size is increased after any send.

Follow-up of #70.