### PR TITLE
Add esp32 platform to compile examples github workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -56,6 +56,11 @@ jobs:
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
             libraries: ""
+          - fqbn: "esp32:esp32:esp32"
+            platforms: |
+              - name: esp32:esp32
+                source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+            libraries: ""
 
     steps:
       - name: Checkout repository

--- a/examples/WiFiAdvancedCallback/WiFiAdvancedCallback.ino
+++ b/examples/WiFiAdvancedCallback/WiFiAdvancedCallback.ino
@@ -22,6 +22,8 @@
   #include <WiFi101.h>
 #elif defined(ARDUINO_ESP8266_ESP12)
   #include <ESP8266WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
 #endif
 
 #include "arduino_secrets.h"

--- a/examples/WiFiEcho/WiFiEcho.ino
+++ b/examples/WiFiEcho/WiFiEcho.ino
@@ -18,6 +18,8 @@
   #include <WiFi101.h>
 #elif defined(ARDUINO_ESP8266_ESP12)
   #include <ESP8266WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
 #endif
 
 #include "arduino_secrets.h"

--- a/examples/WiFiEchoCallback/WiFiEchoCallback.ino
+++ b/examples/WiFiEchoCallback/WiFiEchoCallback.ino
@@ -19,6 +19,8 @@
   #include <WiFi101.h>
 #elif defined(ARDUINO_ESP8266_ESP12)
   #include <ESP8266WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
 #endif
 
 #include "arduino_secrets.h"

--- a/examples/WiFiSimpleReceive/WiFiSimpleReceive.ino
+++ b/examples/WiFiSimpleReceive/WiFiSimpleReceive.ino
@@ -17,6 +17,8 @@
   #include <WiFi101.h>
 #elif defined(ARDUINO_ESP8266_ESP12)
   #include <ESP8266WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
 #endif
 
 #include "arduino_secrets.h"

--- a/examples/WiFiSimpleReceiveCallback/WiFiSimpleReceiveCallback.ino
+++ b/examples/WiFiSimpleReceiveCallback/WiFiSimpleReceiveCallback.ino
@@ -18,6 +18,8 @@
   #include <WiFi101.h>
 #elif defined(ARDUINO_ESP8266_ESP12)
   #include <ESP8266WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
 #endif
 
 #include "arduino_secrets.h"

--- a/examples/WiFiSimpleSender/WiFiSimpleSender.ino
+++ b/examples/WiFiSimpleSender/WiFiSimpleSender.ino
@@ -17,6 +17,8 @@
   #include <WiFi101.h>
 #elif defined(ARDUINO_ESP8266_ESP12)
   #include <ESP8266WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
 #endif
 
 #include "arduino_secrets.h"


### PR DESCRIPTION
This library is used by ArduinoIoTCloud that supports also esp32, so i thougth it was a good idea adding the platform also here.

Merge after #72 and #74