### PR TITLE
Extend example support to generic ARDUINO_ARCH_ESP8266

### DIFF
--- a/examples/WiFiAdvancedCallback/WiFiAdvancedCallback.ino
+++ b/examples/WiFiAdvancedCallback/WiFiAdvancedCallback.ino
@@ -20,7 +20,7 @@
   #include <WiFiNINA.h>
 #elif defined(ARDUINO_SAMD_MKR1000)
   #include <WiFi101.h>
-#elif defined(ARDUINO_ESP8266_ESP12)
+#elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
 #endif
 

--- a/examples/WiFiEcho/WiFiEcho.ino
+++ b/examples/WiFiEcho/WiFiEcho.ino
@@ -16,7 +16,7 @@
   #include <WiFiNINA.h>
 #elif defined(ARDUINO_SAMD_MKR1000)
   #include <WiFi101.h>
-#elif defined(ARDUINO_ESP8266_ESP12)
+#elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
 #endif
 

--- a/examples/WiFiEchoCallback/WiFiEchoCallback.ino
+++ b/examples/WiFiEchoCallback/WiFiEchoCallback.ino
@@ -17,7 +17,7 @@
   #include <WiFiNINA.h>
 #elif defined(ARDUINO_SAMD_MKR1000)
   #include <WiFi101.h>
-#elif defined(ARDUINO_ESP8266_ESP12)
+#elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
 #endif
 

--- a/examples/WiFiSimpleReceive/WiFiSimpleReceive.ino
+++ b/examples/WiFiSimpleReceive/WiFiSimpleReceive.ino
@@ -15,7 +15,7 @@
   #include <WiFiNINA.h>
 #elif defined(ARDUINO_SAMD_MKR1000)
   #include <WiFi101.h>
-#elif defined(ARDUINO_ESP8266_ESP12)
+#elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
 #endif
 

--- a/examples/WiFiSimpleReceiveCallback/WiFiSimpleReceiveCallback.ino
+++ b/examples/WiFiSimpleReceiveCallback/WiFiSimpleReceiveCallback.ino
@@ -16,7 +16,7 @@
   #include <WiFiNINA.h>
 #elif defined(ARDUINO_SAMD_MKR1000)
   #include <WiFi101.h>
-#elif defined(ARDUINO_ESP8266_ESP12)
+#elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
 #endif
 

--- a/examples/WiFiSimpleSender/WiFiSimpleSender.ino
+++ b/examples/WiFiSimpleSender/WiFiSimpleSender.ino
@@ -15,7 +15,7 @@
   #include <WiFiNINA.h>
 #elif defined(ARDUINO_SAMD_MKR1000)
   #include <WiFi101.h>
-#elif defined(ARDUINO_ESP8266_ESP12)
+#elif defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
 #endif
 


### PR DESCRIPTION
Currently the CI is failing for ESP8266 because it is building for `huzzah` board, but in the examples the correct include path is enabled only for `ESPino` boards.

Extending support as we already do for other libraries should fix the issue.