### PR TITLE
Extension of WiFi connection delay before restart WiFi.begin()

### DIFF
--- a/examples/WiFiAdvancedCallback/WiFiAdvancedCallback.ino
+++ b/examples/WiFiAdvancedCallback/WiFiAdvancedCallback.ino
@@ -64,7 +64,7 @@ void setup() {
   while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
     // failed, retry
     Serial.print(".");
-    delay(5000);
+    delay(15000);
   }
 
   Serial.println("You're connected to the network");

--- a/examples/WiFiEcho/WiFiEcho.ino
+++ b/examples/WiFiEcho/WiFiEcho.ino
@@ -59,7 +59,7 @@ void setup() {
   while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
     // failed, retry
     Serial.print(".");
-    delay(5000);
+    delay(15000);
   }
 
   Serial.println("You're connected to the network");

--- a/examples/WiFiEchoCallback/WiFiEchoCallback.ino
+++ b/examples/WiFiEchoCallback/WiFiEchoCallback.ino
@@ -59,7 +59,7 @@ void setup() {
   while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
     // failed, retry
     Serial.print(".");
-    delay(5000);
+    delay(15000);
   }
 
   Serial.println("You're connected to the network");

--- a/examples/WiFiSimpleReceive/WiFiSimpleReceive.ino
+++ b/examples/WiFiSimpleReceive/WiFiSimpleReceive.ino
@@ -52,7 +52,7 @@ void setup() {
   while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
     // failed, retry
     Serial.print(".");
-    delay(5000);
+    delay(15000);
   }
 
   Serial.println("You're connected to the network");

--- a/examples/WiFiSimpleReceiveCallback/WiFiSimpleReceiveCallback.ino
+++ b/examples/WiFiSimpleReceiveCallback/WiFiSimpleReceiveCallback.ino
@@ -53,7 +53,7 @@ void setup() {
   while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
     // failed, retry
     Serial.print(".");
-    delay(5000);
+    delay(15000);
   }
 
   Serial.println("You're connected to the network");

--- a/examples/WiFiSimpleSender/WiFiSimpleSender.ino
+++ b/examples/WiFiSimpleSender/WiFiSimpleSender.ino
@@ -57,7 +57,7 @@ void setup() {
   while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
     // failed, retry
     Serial.print(".");
-    delay(5000);
+    delay(15000);
   }
 
   Serial.println("You're connected to the network");


### PR DESCRIPTION
The examples are most likely not going to work if the WiFi AP experiences the slightest delay for association.
Quickfix : longer delay in the loop
