### PR TITLE
Compatibility with new ESP32 cores

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -657,6 +657,20 @@ int MqttClient::connect(const char *host, uint16_t port)
   return connect((uint32_t)0, host, port);
 }
 
+#ifdef ARDUINO_ARCH_ESP32
+int MqttClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
+{
+  setConnectionTimeout(timeout);
+  return connect(ip, port);
+}
+
+int MqttClient::connect(const char *host, uint16_t port, int32_t timeout)
+{
+  setConnectionTimeout(timeout);
+  return connect(host, port);
+}
+#endif
+
 size_t MqttClient::write(uint8_t b)
 {
   return write(&b, sizeof(b));

--- a/src/MqttClient.h
+++ b/src/MqttClient.h
@@ -84,6 +84,10 @@ public:
 #ifdef ESP8266
   virtual int connect(const IPAddress& ip, uint16_t port) { return 0; }; /* ESP8266 core defines this pure virtual in Client.h */
 #endif
+#ifdef ARDUINO_ARCH_ESP32
+  virtual int connect(IPAddress ip, uint16_t port, int32_t timeout);
+  virtual int connect(const char *host, uint16_t port, int32_t timeout);
+#endif
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   virtual int available();


### PR DESCRIPTION
Hi,

Starting from version 3.1.x, the ``Client`` [must implement](https://github.com/espressif/arduino-esp32/blob/release/v3.1.x/cores/esp32/Client.h) the following methods:
```c++
  virtual int connect(IPAddress ip, uint16_t port, int32_t timeout) = 0;
  virtual int connect(const char *host, uint16_t port, int32_t timeout) = 0;
```