### PR TITLE
FIxd bug with _rxMessageDup in mqttClient.cpp

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -473,7 +473,7 @@ void MqttClient::poll()
           }
 
           if (_rxType == MQTT_PUBLISH) {
-            _rxMessageDup = (_rxFlags & 0x80) != 0;
+            _rxMessageDup = (_rxFlags & 0x08) != 0;
             _rxMessageQoS = (_rxFlags >> 1) & 0x03;
             _rxMessageRetain = (_rxFlags & 0x01);
 


### PR DESCRIPTION
I had a chance to spot this possible bug. I believe line 476 of file `mqttClient.cpp` should read `_rxMessageDup = (_rxFlags & 0x08) != 0;` and NOT `_rxMessageDup = (_rxFlags & 0x80) != 0;` as it is now. Here is the fix.